### PR TITLE
github_uid patch

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   def connect_github(data)
     self.update!( github_uid: data["uid"],
                   github_token: data['credentials']['token'],
-                  github_url: data['extra']['raw_info']['html_url'],
+                  github_url: data['info']['urls']['GitHub'],
                   github_handle: data['extra']['raw_info']['login'] )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,10 @@ class User < ApplicationRecord
   has_secure_password
 
   def connect_github(data)
-    self.update!(github_token: data['credentials']['token'],
-                 github_url: data['extra']['raw_info']['html_url'],
-                 github_handle: data['extra']['raw_info']['login'])
+    self.update!( github_uid: data["uid"],
+                  github_token: data['credentials']['token'],
+                  github_url: data['extra']['raw_info']['html_url'],
+                  github_handle: data['extra']['raw_info']['login'] )
   end
 
   def has_friends?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe User, type: :model do
     it '#connect_github' do
       user = create(:user, email: "test@email.com", password: "test")
 
-      data =       {"provider"=>"github",
+      data = {"provider"=>"github",
            "uid"=>"42525195",
            "info"=>
             {"nickname"=>"Mackenzie-Frey",
@@ -44,7 +44,10 @@ RSpec.describe User, type: :model do
 
       user.connect_github(data)
 
-      expect(user.github_token).to eq(ENV['OAUTH_TEST_TOKEN'])
+      expect(user.github_token).to eq(data['credentials']['token'])
+      expect(user.github_uid).to eq(data['uid'])
+      expect(user.github_handle).to eq(data['extra']['raw_info']['login'])
+      expect(user.github_url).to eq(data['info']['urls']['GitHub'])
     end
 
     it '#get_friend_users & #get_friends_ids & #has_friends' do


### PR DESCRIPTION
Adds to connect_github method for user to ensure github_uid is saving to the user object. Also alters the location github_url is getting data from in the API response. Adds to testing to ensure a user object does have these attributes assigned to it via the connect_github method.