### PR TITLE
Tutorial show

### DIFF
--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -3,67 +3,75 @@
 <h1 id="message"></h1>
 <div class="col col-4">
   <h4>Videos</h4>
-  <ul>
-    <% @facade.videos.each do |video| %>
-      <li>
-        <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
-      </li>
-    <% end %>
-  </ul>
-</div>
-
-<div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <% if current_user %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-      <% else %>
-      <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+  <% if @facade.videos.count > 0 %>
+    <ul>
+      <% @facade.videos.each do |video| %>
+        <li>
+          <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
+        </li>
       <% end %>
-    </div>
-  </div>
+    </ul>
 
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
+    <div class="col col-8">
+      <div class="title-bookmark">
+        <h3><%= @facade.current_video.title %></h3>
+        <div class="bookmarks-btn">
+          <% if current_user %>
+          <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+          <% else %>
+          <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+          <% end %>
+        </div>
+      </div>
+
+      <div id="player">
+        <script src="https://www.youtube.com/player_api"></script>
+        <script>
+        // create youtube player
+        var player;
+        var position;
+        function onYouTubePlayerAPIReady() {
+          player = new YT.Player('player', {
+            width: '640',
+            height: '390',
+            videoId: '<%= @facade.current_video.video_id %>',
+            events: {
+              onReady: onPlayerReady,
+              onStateChange: onPlayerStateChange
+            }
+          });
         }
-      });
-    }
 
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
+        // autoplay video
+        function onPlayerReady(event) {
+          event.target.playVideo();
+        }
 
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
-      }
-    }
-  </script>
-</div>
+        // when video ends
+        function onPlayerStateChange(event) {
+          if(event.data === 0 && <%= @facade.play_next_video? %>) {
+            window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
+          } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
+            const message = document.querySelector(`#message`);
+            message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+          }
+        }
+      </script>
+    </div>
 
-  <h4>Description</h4>
-  <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
-    <%= @facade.current_video.description.truncate(50) %>...
-    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
-  </p>
+      <h4>Description</h4>
+      <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+        <%= @facade.current_video.description.truncate(50) %>...
+        <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
+      </p>
+    </div>
+  <% else %>
+    <ul>
+      <li>
+        <h3>This tutorial doesn't have any videos yet, but we're working on it!</h3>
+      </li>
+    </ul>
+  <% end %>
 </div>
 
 </main>

--- a/spec/features/tutorials/tutorial_show_spec.rb
+++ b/spec/features/tutorials/tutorial_show_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Tutorial show page" do
+  it "displays all videos" do
+  end
+
+  it "displays correctly when it has no videos" do
+    tut1 = create(:tutorial)
+    vid1, vid2 = create_list(:video, 2, tutorial: tut1)
+    tut2 = create(:tutorial)
+
+    visit tutorial_path(tut2)
+
+    expect(current_path).to eq(tutorial_path(tut2))
+    expect(page).to have_content(tut1.title)
+    expect(page).to have_content(vid1.title)
+    expect(page).to have_content(vid2.title)
+    expect(page).to have_content(tut2.title)
+  end
+end

--- a/spec/features/tutorials/tutorial_show_spec.rb
+++ b/spec/features/tutorials/tutorial_show_spec.rb
@@ -2,6 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "Tutorial show page" do
   it "displays all videos" do
+    tut1 = create(:tutorial)
+    vid1, vid2 = create_list(:video, 2, tutorial: tut1)
+
+    visit tutorial_path(tut1)
+
+    expect(current_path).to eq(tutorial_path(tut1))
+    expect(page).to have_content(tut1.title)
+    expect(page).to have_content(vid1.title)
+    expect(page).to have_content(vid2.title)
   end
 
   it "displays correctly when it has no videos" do
@@ -12,9 +21,6 @@ RSpec.describe "Tutorial show page" do
     visit tutorial_path(tut2)
 
     expect(current_path).to eq(tutorial_path(tut2))
-    expect(page).to have_content(tut1.title)
-    expect(page).to have_content(vid1.title)
-    expect(page).to have_content(vid2.title)
-    expect(page).to have_content(tut2.title)
+    expect(page).to have_content("This tutorial doesn't have any videos yet, but we're working on it!")
   end
 end


### PR DESCRIPTION
If a tutorial doesn't have any videos and we visit its show page an error occurs when trying to call current_video.title since current_video is nil.

A possible easy fix is to default to Video.new if there aren't any videos associated with the tutorial.